### PR TITLE
grev_lnx.c: ckeck pointer before calling strstr()

### DIFF
--- a/src/input/grev_lnx.c
+++ b/src/input/grev_lnx.c
@@ -107,7 +107,7 @@ int _GrEventInit(void)
     }
 
     s = getenv("LANG");
-    if (strstr(s,"UTF-8"))
+    if (s && strstr(s,"UTF-8"))
       kbsysencoding = GRENC_UTF_8;
     else {
       s = getenv("MGRXKBSYSENCODING");


### PR DESCRIPTION
This is a small fix I needed to run MGRX.

I really appreciate this kind of software for making graphics.
Regarding the MGRX font format (.fnt file), I assume that a conversion tool exists to generate the fonts available in the package.
But I couldn't find any information about it ?